### PR TITLE
`Pool` is already an `Arc`

### DIFF
--- a/app/src/server/database.rs
+++ b/app/src/server/database.rs
@@ -1,24 +1,24 @@
-use std::{env, sync::Arc};
+use std::env;
 
 use once_cell::sync::OnceCell;
 use sqlx::{migrate::Migrator, pool::PoolOptions, Error, Pool, Postgres};
 
 static MIGRATOR: Migrator = sqlx::migrate!();
-static POOL: OnceCell<Arc<Pool<Postgres>>> = OnceCell::new();
+static POOL: OnceCell<Pool<Postgres>> = OnceCell::new();
 
 pub async fn run_migrations() -> Result<(), Error> {
-    MIGRATOR.run(&**POOL.get().unwrap()).await?;
+    MIGRATOR.run(&*POOL.get().unwrap()).await?;
     Ok(())
 }
 
 pub async fn init_db_pool() -> Result<(), Error> {
-    POOL.set(Arc::new(
+    POOL.set(
         PoolOptions::<Postgres>::new()
             .max_connections(5)
             .connect(&env::var("DATABASE_URL").expect("DATABASE_URL must be set"))
             .await
             .unwrap(),
-    ))
+    )
     .expect("database pool must be empty on initialization");
     Ok(())
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Optimized the database connection pool management for better performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->